### PR TITLE
Add security headers to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Security
+
+This project sends common HTTP security headers by default. See `next.config.mjs` for the exact list of headers applied to every response.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,48 @@
+/** Security headers applied to all routes */
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value:
+      "default-src 'self'; img-src 'self' https: data:; object-src 'none';",
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'off',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+]
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    distDir: 'dist',
-    output: 'standalone',
-};
+  distDir: 'dist',
+  output: 'standalone',
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ]
+  },
+}
 
-export default nextConfig;
+export default nextConfig


### PR DESCRIPTION
## Summary
- secure the app by sending common HTTP security headers for every route
- document these headers in README

## Testing
- `npx @biomejs/biome lint next.config.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685305aa9f088324af25efa391cd7b12