### PR TITLE
Add security headers and API rate limiting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,37 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+  {
+    key: 'Content-Security-Policy',
+    value:
+      "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'",
+  },
+];
+
 const nextConfig = {
-	distDir: "dist",
+  distDir: 'dist',
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const isDev = process.env.NODE_ENV === 'development';
+
 const securityHeaders = [
   { key: 'X-DNS-Prefetch-Control', value: 'on' },
   { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
@@ -17,8 +19,9 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value:
-      "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'",
+    value: isDev
+      ? "default-src 'self'; img-src 'self' data: blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; font-src 'self' data:;"
+      : "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' data:;",
   },
 ];
 

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -1,0 +1,32 @@
+export interface RateLimitOptions {
+  windowMs: number;
+  maxRequests: number;
+}
+
+interface RateRecord {
+  count: number;
+  expires: number;
+}
+
+const records = new Map<string, RateRecord>();
+
+export function checkRateLimit(
+  identifier: string,
+  { windowMs, maxRequests }: RateLimitOptions,
+): boolean {
+  const now = Date.now();
+  const record = records.get(identifier) || {
+    count: 0,
+    expires: now + windowMs,
+  };
+
+  if (now > record.expires) {
+    record.count = 0;
+    record.expires = now + windowMs;
+  }
+
+  record.count += 1;
+  records.set(identifier, record);
+
+  return record.count <= maxRequests;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,35 +8,36 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { checkRateLimit } from "./lib/security/rate-limit";
 import {
-	type EdgeRequestContext,
-	extractEdgeRequestContext,
-	logEdgeError,
-	logEdgeHttpRequest,
+  type EdgeRequestContext,
+  extractEdgeRequestContext,
+  logEdgeError,
+  logEdgeHttpRequest,
 } from "./lib/logger/edge-logger";
 
 const RATE_LIMIT_WINDOW = 60_000; // 1 minute
 const RATE_LIMIT_MAX = 50; // max requests per IP per window
 
 function applySecurityHeaders(response: NextResponse) {
-        response.headers.set("X-DNS-Prefetch-Control", "on");
-        response.headers.set("X-Frame-Options", "SAMEORIGIN");
-        response.headers.set("X-Content-Type-Options", "nosniff");
-        response.headers.set(
-                "Strict-Transport-Security",
-                "max-age=63072000; includeSubDomains; preload",
-        );
-        response.headers.set(
-                "Referrer-Policy",
-                "strict-origin-when-cross-origin",
-        );
-        response.headers.set(
-                "Permissions-Policy",
-                "camera=(), microphone=(), geolocation=()",
-        );
-        response.headers.set(
-                "Content-Security-Policy",
-                "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'",
-        );
+  const isDev = process.env.NODE_ENV === "development";
+
+  response.headers.set("X-DNS-Prefetch-Control", "on");
+  response.headers.set("X-Frame-Options", "SAMEORIGIN");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload"
+  );
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set(
+    "Permissions-Policy",
+    "camera=(), microphone=(), geolocation=()"
+  );
+  response.headers.set(
+    "Content-Security-Policy",
+    isDev
+      ? "default-src 'self'; img-src 'self' data: blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; font-src 'self' data:;"
+      : "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' data:;"
+  );
 }
 
 /**
@@ -44,83 +45,83 @@ function applySecurityHeaders(response: NextResponse) {
  * Logs all incoming requests with comprehensive metadata
  */
 export async function middleware(request: NextRequest) {
-        const startTime = Date.now();
+  const startTime = Date.now();
 
-        // Extract request context for logging
-        const context: EdgeRequestContext = {
-                ...extractEdgeRequestContext(request),
-                startTime,
-        };
+  // Extract request context for logging
+  const context: EdgeRequestContext = {
+    ...extractEdgeRequestContext(request),
+    startTime,
+  };
 
-        try {
-                if (request.nextUrl.pathname.startsWith('/api')) {
-                        const ip =
-                                request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-                                request.headers.get('x-real-ip') ||
-                                'unknown';
-                        const allowed = checkRateLimit(ip, {
-                                windowMs: RATE_LIMIT_WINDOW,
-                                maxRequests: RATE_LIMIT_MAX,
-                        });
-                        if (!allowed) {
-                                return NextResponse.json(
-                                        { error: 'Too many requests' },
-                                        { status: 429 },
-                                );
-                        }
-                }
-                // Continue with the request
-                const response = NextResponse.next();
+  try {
+    if (request.nextUrl.pathname.startsWith("/api")) {
+      const ip =
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        request.headers.get("x-real-ip") ||
+        "unknown";
+      const allowed = checkRateLimit(ip, {
+        windowMs: RATE_LIMIT_WINDOW,
+        maxRequests: RATE_LIMIT_MAX,
+      });
+      if (!allowed) {
+        return NextResponse.json(
+          { error: "Too many requests" },
+          { status: 429 }
+        );
+      }
+    }
+    // Continue with the request
+    const response = NextResponse.next();
 
-                // Add request ID to response headers for debugging
-                response.headers.set("x-request-id", context.requestId);
-                applySecurityHeaders(response);
+    // Add request ID to response headers for debugging
+    response.headers.set("x-request-id", context.requestId);
+    applySecurityHeaders(response);
 
-		// Calculate response time
-		const responseTime = Date.now() - startTime;
+    // Calculate response time
+    const responseTime = Date.now() - startTime;
 
-		// Log the request after response is ready
-		const statusCode = response.status;
+    // Log the request after response is ready
+    const statusCode = response.status;
 
-		// Skip logging for certain paths to reduce noise
-		const shouldSkipLogging = shouldSkipPath(request.nextUrl.pathname);
+    // Skip logging for certain paths to reduce noise
+    const shouldSkipLogging = shouldSkipPath(request.nextUrl.pathname);
 
-		if (!shouldSkipLogging) {
-			logEdgeHttpRequest(context, statusCode, responseTime, {
-				// Add any additional metadata here
-				path: request.nextUrl.pathname,
-				query: Object.fromEntries(request.nextUrl.searchParams),
-				referer: request.headers.get("referer"),
-			});
-		}
+    if (!shouldSkipLogging) {
+      logEdgeHttpRequest(context, statusCode, responseTime, {
+        // Add any additional metadata here
+        path: request.nextUrl.pathname,
+        query: Object.fromEntries(request.nextUrl.searchParams),
+        referer: request.headers.get("referer"),
+      });
+    }
 
-                return response;
-        } catch (error) {
-                // Log any middleware errors
-                const responseTime = Date.now() - startTime;
+    return response;
+  } catch (error) {
+    // Log any middleware errors
+    const responseTime = Date.now() - startTime;
 
-		logEdgeError(
-			error instanceof Error ? error : new Error("Unknown middleware error"),
-			context,
-			{
-				path: request.nextUrl.pathname,
-				responseTime: `${responseTime}ms`,
-			},
-		);
+    logEdgeError(
+      error instanceof Error ? error : new Error("Unknown middleware error"),
+      context,
+      {
+        path: request.nextUrl.pathname,
+        responseTime: `${responseTime}ms`,
+      }
+    );
 
-                // Return error response
-                const errorResponse = NextResponse.json(
-                        { error: "Internal Server Error" },
-                        {
-                                status: 500,
-                                headers: {
-                                        "x-request-id": context.requestId,
-                                },
-                        },
-                );
-                applySecurityHeaders(errorResponse);
-                return errorResponse;
-        }
+    // Return error response
+    const errorResponse = NextResponse.json(
+      { error: "Internal Server Error" },
+      {
+        status: 500,
+        headers: {
+          "x-request-id": context.requestId,
+        },
+      }
+    );
+    applySecurityHeaders(errorResponse);
+    return errorResponse;
+  }
 }
 
 /**
@@ -128,32 +129,32 @@ export async function middleware(request: NextRequest) {
  * Reduces noise from static assets and health checks
  */
 function shouldSkipPath(pathname: string): boolean {
-        const skipPatterns = [
-                "/_next/static", // Next.js static assets
-                "/_next/image", // Next.js image optimization
-                "/favicon.ico", // Favicon requests
-                "/api", // API routes handle their own logging
-                "/robots.txt", // SEO files
-                "/sitemap.xml", // SEO files
-                "/health", // Health check endpoints
-		"/ping", // Ping endpoints
-		"/.well-known", // Well-known URIs
-	];
+  const skipPatterns = [
+    "/_next/static", // Next.js static assets
+    "/_next/image", // Next.js image optimization
+    "/favicon.ico", // Favicon requests
+    "/api", // API routes handle their own logging
+    "/robots.txt", // SEO files
+    "/sitemap.xml", // SEO files
+    "/health", // Health check endpoints
+    "/ping", // Ping endpoints
+    "/.well-known", // Well-known URIs
+  ];
 
-	return skipPatterns.some((pattern) => pathname.startsWith(pattern));
+  return skipPatterns.some((pattern) => pathname.startsWith(pattern));
 }
 
 /**
  * Configure which paths the middleware should run on
  */
 export const config = {
-	matcher: [
-                /*
-                 * Match all request paths except:
-                 * - _next/static (static files)
-                 * - _next/image (image optimization files)
-                 * - favicon.ico (favicon file)
-                 */
-                "/((?!_next/static|_next/image|favicon.ico).*)",
-        ],
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
 };


### PR DESCRIPTION
## Summary
- add security headers via Next.js config
- implement memory-based rate limiting for API routes
- set secure headers and rate limit check in middleware

## Testing
- `pnpm install`
- `pnpm build` *(fails: DATABASE_URL environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_6861c0aebeb88324a68134aba211b2fb